### PR TITLE
Pre calc speed up

### DIFF
--- a/src/hexdump2/__main__.py
+++ b/src/hexdump2/__main__.py
@@ -19,7 +19,7 @@ from hexdump2 import hexdump
 def _setup_arg_parser():
     """Creates argument parser for main function.
 
-    :return: argpase arugment parser object
+    :return: argparse argument parser object
     """
 
     def _auto_int(value):

--- a/src/hexdump2/__main__.py
+++ b/src/hexdump2/__main__.py
@@ -1,3 +1,6 @@
+"""
+Main function module for hexdump2
+"""
 import argparse
 import sys
 from os import linesep
@@ -13,7 +16,12 @@ except ModuleNotFoundError:
 from hexdump2 import hexdump
 
 
-def setup_arg_parser():
+def _setup_arg_parser():
+    """Creates argument parser for main function.
+
+    :return: argpase arugment parser object
+    """
+
     def _auto_int(value):
         try:
             return int(value, 0)
@@ -66,18 +74,22 @@ def setup_arg_parser():
 
 
 def main():
-    parser = setup_arg_parser()
+    """Main function run by console script hexdump2 or hd2.  Also run by `python -m hexdump2` on
+    command line.
+    :return: system exit return code.
+    """
+    parser = _setup_arg_parser()
     args = parser.parse_args()
 
     try:
         for file in args.file:
-            with file.open("rb") as fh:
+            with file.open("rb") as file_obj:
                 file_size = file.lstat().st_size
                 read_start = args.offset if args.offset is not None else 0
                 length = args.length if args.length is not None else file_size
 
                 hexdump(
-                    fh.read(length),
+                    file_obj.read(length),
                     offset=read_start,
                     collapse=args.verbose_output,
                     color=args.color,

--- a/src/hexdump2/hexdump2.py
+++ b/src/hexdump2/hexdump2.py
@@ -109,7 +109,7 @@ def _line_gen(
             # Use the `iso-8859-1` or `latin-1` encodings to map 0x00 to 0xff to bytes
             # 0x00 to 0xff.
             # c.f. https://docs.python.org/3/library/codecs.html#encodings-and-unicode
-            data = memoryview(bytes(data, encoding="iso-8859-1"))
+            data = bytes(data, encoding="iso-8859-1")
         else:
             data = bytes(data)
 

--- a/src/hexdump2/hexdump2.py
+++ b/src/hexdump2/hexdump2.py
@@ -139,7 +139,7 @@ def _line_gen(
                     hex_str_pad += len(character_color)
 
                 yield_star = True
-                yield f"{address_color}{address_value:08x}  " f"{hex_str: <{hex_str_pad}}" f"{reset_color}|{ascii_str}{reset_color}|{linesep}"
+                yield f"{address_color}{address_value:08x}  {hex_str: <{hex_str_pad}}{reset_color}|{ascii_str}{reset_color}|{linesep}"
 
             last_line_data = line_data
 

--- a/src/hexdump2/hexdump2.py
+++ b/src/hexdump2/hexdump2.py
@@ -1,13 +1,14 @@
 """
 Contains the functionality for creating hexdump lines from input data.
 """
-from os import linesep, environ
-from typing import Union, ByteString, Iterator, Literal
+from os import environ, linesep, name as os_name
+from typing import ByteString, Iterator, Literal, Union
 
 try:
     import colorama
 
-    colorama.init(autoreset=True)  # Only needed for Windows
+    if os_name == "nt":
+        colorama.init(autoreset=True)  # Only needed for Windows
 except ImportError:
     colorama = None
 

--- a/tests/test_hexdump2.py
+++ b/tests/test_hexdump2.py
@@ -11,8 +11,9 @@ from os import environ, linesep
 from types import GeneratorType
 from unittest.mock import patch
 
+import hexdump2.__main__
+
 from hexdump2 import hd, hexdump
-from hexdump2.__main__ import main
 
 single_line_result = (
     f"00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|{linesep}"
@@ -79,7 +80,7 @@ colored_0x100_nulls = r"""[32m00000000  [39m00 [39m00 [39m00 [39m00 [39m00
 class TestHexdump2(unittest.TestCase):
     def test_bad_return(self):
         with self.assertRaises(ValueError):
-            hexdump(bytes(16), "bad_arg")
+            hexdump(bytes(16), "bad_arg")  # noqa
 
     def test_return_print(self):
         data = bytes(16)
@@ -227,7 +228,7 @@ class TestHexdump2(unittest.TestCase):
 
     @unittest.skip("Messes with other tests.")
     def test_enable_color_always(self):
-        from hexdump2.hexdump2 import color_always
+        from hexdump2.hexdump2 import color_always  # noqa
 
         r = hexdump(bytes(0x100), result="return")
         self.assertNotEqual(colored_0x100_nulls, r)
@@ -250,7 +251,7 @@ class TestHexdump2(unittest.TestCase):
         with self.assertRaises(TypeError) as cm:
             hexdump(Item())
 
-        self.assertIn("subscriptable", cm.exception.args[0])
+        self.assertIn("object to bytes", cm.exception.args[0])
 
     # noinspection PyTypeChecker
     def test_object_without_len(self):
@@ -264,7 +265,7 @@ class TestHexdump2(unittest.TestCase):
 
     def test_string_conversion(self):
         test_str = "".join(chr(_) for _ in range(256))
-        r = hexdump(test_str, result="return")
+        r = hexdump(test_str, result="return")  # noqa
         self.assertEqual(r, range_0x100_result)
 
 
@@ -302,7 +303,7 @@ class TestClassHD(unittest.TestCase):
 class TestCommandLineInterface(unittest.TestCase):
     def _call_main(self, expected_return_code: int = 0):
         with self.assertRaises(SystemExit) as cm:
-            main()
+            hexdump2.__main__.main()
         rc = cm.exception
         self.assertEqual(expected_return_code, rc.code)
 
@@ -365,7 +366,7 @@ class TestCommandLineInterface(unittest.TestCase):
         import hexdump2.hexdump2
 
         old_colorama = colorama
-        sys.modules["colorama"] = None
+        sys.modules["colorama"] = None  # noqa
         importlib.reload(hexdump2.hexdump2)
 
         data = bytes(range(256))

--- a/tests/test_hexdump2.py
+++ b/tests/test_hexdump2.py
@@ -7,11 +7,11 @@ import sys
 import tempfile
 import unittest
 from io import StringIO
-from os import linesep, environ
+from os import environ, linesep
 from types import GeneratorType
 from unittest.mock import patch
 
-from hexdump2 import hexdump, hd
+from hexdump2 import hd, hexdump
 from hexdump2.__main__ import main
 
 single_line_result = (
@@ -359,6 +359,21 @@ class TestCommandLineInterface(unittest.TestCase):
                 sys, "argv", test_args
             ), StringIO() as buf, contextlib.redirect_stderr(buf):
                 self._call_main(2)
+
+    def test_no_colorama(self):
+        import colorama
+        import hexdump2.hexdump2
+
+        old_colorama = colorama
+        sys.modules["colorama"] = None
+        importlib.reload(hexdump2.hexdump2)
+
+        data = bytes(range(256))
+        r = hexdump(data, "return", color=True)
+        self.assertNotEqual(colored_ascii_range, r)
+
+        sys.modules["colorama"] = old_colorama
+        importlib.reload(hexdump2.hexdump2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This branch is a bunch of testing to improve the speed and reduce complexity of hexdump2.  Tested against develop branch (in ipython):
```ipython
d=bytes(range(256))*16
from hexdump2 import hexdump as hd
%timeit _=hd(d,result="return")
6.51 ms ± 46.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
Tested with PR:
```ipython
d=bytes(range(256))*16
from hexdump2 import hexdump as hd
%timeit _=hd(d,result="return")
3.15 ms ± 79.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```